### PR TITLE
Linux support: use wine when calling exes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,14 @@ __Blender must be restarted for the changes to take effect__<br />
 - **ai_mesh**: true or false
 - **autodel**: true or false
 - **bin_copy**: true or false
-- **bsp_dir**: Path surrounded by "s. Use \\\ rather than just \\ to separate each part of a path.
+- **bsp_dir**: Path surrounded by "s. Use \\\ rather than just \\ to separate each part of a path. Linux users should use / to separate instead.
 - **bsp_optimization**: 0 - 3
 - **centering**: true or false
 - **game_dirs**: Multiple paths should be separated by a semicolon (and use \\\ rather than \\). Example: "**C:\\\Games\\\Thief2;C:\\\Games\\\Shock2**" will give you this menu:<br />
-![](Screenshots/game_dirs.JPG)
+![](Screenshots/game_dirs.JPG)<br />
+Note: On Linux use the path to the game under wineprefix (eg. \<path to games\>/games/wine/drive_c/thief2 or $HOME/.wine/drive_c/thief2)
 - **selection_only**: true or false
 - **smooth_angle**: 0 - 360 (not a fixed limit, but unlikely to need much more beyond 120) 
 - **tex_copy**: 0, 1 or 2, which correspond with menu the menu items you see during Export<br />
+- **wineprefix**: path to wine prefix (Linux only)
 ![](BlenderNDToolkit/CopyTexOptions.jpg)

--- a/__init__.py
+++ b/__init__.py
@@ -53,6 +53,7 @@ default_config = {
 'smooth_angle': 89,
 'game_dirs': 'C:\\Games\\Thief2',
 'bsp_meshbld_dir': 'C:\\Games\\Thief2\\Tools\\3dstobin\\3ds\\Workshop',
+'wineprefix': '$HOME/.wine',
 'autodel': False,
 'bin_copy': True,
 'tex_copy': 1
@@ -147,6 +148,7 @@ class ExportBin(bpy.types.Operator, ExportHelper):
     use_coplanar_limit: BoolProperty(name='Use Coplanar Limit', description='Disable this if you can see errors in your object\'s shape', default = True)
     coplanar_limit: FloatProperty(name='Coplanar Limit', description='Change this if you get small gaps in the model or flattened faces', default = 1.0)
     
+    wineprefix: StringProperty(default=tryConfig('wineprefix', config_from_file), name='Wine prefix', description='Wine prefix to use while executing BSP.exe and/or MeshBld.exe (Linux only)')
     bsp_dir: StringProperty(default=tryConfig('bsp_meshbld_dir', config_from_file), name='BSP/MeshBld Dir', description='Folder containing BSP.exe and/or MeshBld.exe')
     
     #generate game dirs list


### PR DESCRIPTION
Just a small tweak to add in the ability to configure path to a wine prefix, and use that along side wine when calling exes during export when under linux.
Also adds in extra info to the readme.md for linux users